### PR TITLE
2024/10/04

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -137,7 +137,23 @@ export -f regard
 
 alias rm='recycle'
 recycle() {
-    mv $@ ~/Trash
+    if [ $1 == "-r" ]
+    then
+        mv $@ ~/Trash
+        return $?
+        shift
+    elif [ $1 == "-rx" ]
+    then
+        shift
+        /usr/bin/rm -r $@
+        return $?
+    elif [ $1 == "-x" ]
+    then
+        shift
+        /usr/bin/rm $@
+        return $?
+    fi
+    return 1
 }
 export -f recycle
 


### PR DESCRIPTION
Fixed recycle function with absolute paths to rm command. Don't alias a command to a function and then use that alias in the function.